### PR TITLE
Fix "sort_order" bug in catalog query view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0.8 (unreleased)
 ------------------
 
+- Fix "sort_order" bug in catalog query view.
+  The problem is that the catalog does not support unicode strings.
+  [jone]
+
 - Fix watcher.js (replace jq with $).
   [mathias.leimgruber]
 

--- a/ftw/bridge/client/browser/catalog.py
+++ b/ftw/bridge/client/browser/catalog.py
@@ -3,13 +3,14 @@ from Products.Five import BrowserView
 from copy import deepcopy
 from ftw.bridge.client.interfaces import IBrainSerializer
 from ftw.bridge.client.utils import json
+from ftw.bridge.client.utils import to_utf8_recursively
 from zope.component import getUtility
 
 
 class BridgeSearchCatalog(BrowserView):
 
     def __call__(self):
-        query = json.loads(self.request.get('query'))
+        query = to_utf8_recursively(json.loads(self.request.get('query')))
         limit = int(self.request.get('limit'))
         brains = self._query_catalog(query, limit)
 

--- a/ftw/bridge/client/testing.py
+++ b/ftw/bridge/client/testing.py
@@ -1,5 +1,8 @@
 from Products.CMFCore.utils import getToolByName
 from StringIO import StringIO
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
 from ftw.testing.layer import ComponentRegistryLayer
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
@@ -75,7 +78,8 @@ PLONE_TESTING_LAYER = PloneTestingLayer()
 
 class IntegrationTestingLayer(PloneTestingLayer):
 
-    defaultBases = (PLONE_INTEGRATION_TESTING,)
+    defaultBases = (PLONE_INTEGRATION_TESTING,
+                    BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         # Load ZCML
@@ -105,7 +109,9 @@ class FunctionTestingLayer(PloneTestingLayer):
 
 FUNCTIONAL_FIXTURE = FunctionTestingLayer()
 FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(FUNCTIONAL_FIXTURE,), name='ftw.bridge.client:Functional')
+    bases=(FUNCTIONAL_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
+    name='ftw.bridge.client:Functional')
 
 
 class ExampleContentLayer(PloneSandboxLayer):

--- a/ftw/bridge/client/tests/test_utils.py
+++ b/ftw/bridge/client/tests/test_utils.py
@@ -3,6 +3,7 @@ from ftw.bridge.client.interfaces import PORTAL_URL_PLACEHOLDER
 from ftw.bridge.client.testing import EXAMPLE_CONTENT_LAYER
 from ftw.bridge.client.utils import get_brain_url
 from ftw.bridge.client.utils import get_object_url
+from ftw.bridge.client.utils import to_utf8_recursively
 from unittest2 import TestCase
 
 
@@ -27,3 +28,33 @@ class TestUtils(TestCase):
         self.assertEqual(
             get_brain_url(brains[0]),
             '%sfeed-folder/page' % PORTAL_URL_PLACEHOLDER)
+
+
+class TestToUtf8Recursively(TestCase):
+
+    def test_converts_strings(self):
+        self.assertEquals(str, type(to_utf8_recursively(u'foo')))
+        self.assertEquals(str, type(to_utf8_recursively('foo')))
+
+    def test_keeps_integers(self):
+        self.assertEquals(2, to_utf8_recursively(2))
+
+    def test_converts_lists_recursively(self):
+        self.assertEquals([str, str],
+                          map(type, to_utf8_recursively([u'foo', 'bar'])))
+        self.assertEquals(['foo', 'bar'],
+                          to_utf8_recursively([u'foo', 'bar']))
+
+    def test_converts_dicts_recursively(self):
+        input = {u'foo': u'Foo',
+                 'bar': 'Bar'}
+
+        self.assertEquals([str, str],
+                          map(type, to_utf8_recursively(input).keys()))
+
+        self.assertEquals([str, str],
+                          map(type, to_utf8_recursively(input).values()))
+
+        # assertEquals does not make any type comparision.
+        # We just test that the value is the same.
+        self.assertEquals(input, to_utf8_recursively(input))

--- a/ftw/bridge/client/utils.py
+++ b/ftw/bridge/client/utils.py
@@ -21,3 +21,15 @@ def get_brain_url(brain):
     """
     portal_url = getToolByName(brain, 'portal_url')() + '/'
     return brain.getURL().replace(portal_url, PORTAL_URL_PLACEHOLDER)
+
+
+def to_utf8_recursively(data):
+    if isinstance(data, unicode):
+        return data.encode('utf-8')
+    elif isinstance(data, list):
+        return map(to_utf8_recursively, data)
+    elif isinstance(data, dict):
+        return dict(map(lambda item: map(to_utf8_recursively, item),
+                        data.items()))
+    else:
+        return data

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ tests_require = [
     'plone.mocktestcase',
     'plone.app.testing',
     'ftw.testing',
+    'ftw.builder',
 
     'transaction',
     'zope.browser',


### PR DESCRIPTION
The problem is that the catalog does not support unicode strings, resulting in wrongly sorted brains.
Since the query is submitted via HTTP in json and `json.loads` always returns unicodes, we need to recursively convert the strings back to `utf-8`.

/ @maethu 
