### PR TITLE
Drop support for older ftw.tabbedview versions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.0.8 (unreleased)
 ------------------
 
+- Drop support for older ftw.tabbedview versions.
+  Requires ftw.tabbedview>=3.2.3.
+  This fixes a ZCML autoinclude load order issue.
+  [jone]
+
 - Fix "sort_order" bug in catalog query view.
   The problem is that the catalog does not support unicode strings.
   [jone]

--- a/ftw/bridge/client/configure.zcml
+++ b/ftw/bridge/client/configure.zcml
@@ -13,7 +13,7 @@
     <include package=".browser" />
     <include package=".portlets" />
 
-    <configure zcml:condition="have ftw.tabbedview3">
+    <configure zcml:condition="installed ftw.tabbedview">
         <include package=".tabbed" />
     </configure>
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ tests_require = [
 extras_require = {
     'tests': tests_require,
     'tabbedview': [
-        'ftw.tabbedview',
+        'ftw.tabbedview>=3.2.3',
         'ftw.table']}
 
 tests_require += extras_require['tabbedview']


### PR DESCRIPTION
Requires ftw.tabbedview>=3.2.3.
This fixes a ZCML autoinclude load order issue.

/ @maethu 
