### PR TITLE
Brain serializer: fix JSON error when there persistent mutables in the catalog

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Brain serializer: fix JSON error when there persistent mutables in the catalog.
+  [jone]
 
 
 1.0.9 (2014-08-20)

--- a/ftw/bridge/client/brain.py
+++ b/ftw/bridge/client/brain.py
@@ -1,10 +1,12 @@
-import DateTime
 from ftw.bridge.client.interfaces import IBrainRepresentation
 from ftw.bridge.client.interfaces import IBrainSerializer
 from ftw.bridge.client.utils import get_brain_url
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
 from Products.CMFCore.utils import getToolByName
 from zope.component.hooks import getSite
 from zope.interface import implements
+import DateTime
 import Missing
 
 
@@ -48,7 +50,20 @@ class BrainSerializer(object):
             return [':DateTime', str(value)]
 
         elif isinstance(value, tuple):
-            return list(value)
+            return self._encode(list(value))
+
+        elif isinstance(value, PersistentMapping):
+            return self._encode(dict(value))
+
+        elif isinstance(value, dict):
+            return dict((self._encode(key), self._encode(value))
+                        for key, value in value.items())
+
+        elif isinstance(value, PersistentList):
+            return self._encode(list(value))
+
+        elif isinstance(value, list):
+            return map(self._encode, value)
 
         return value
 

--- a/ftw/bridge/client/tests/test_brain.py
+++ b/ftw/bridge/client/tests/test_brain.py
@@ -6,6 +6,8 @@ from ftw.bridge.client.interfaces import IBrainSerializer
 from ftw.bridge.client.testing import INTEGRATION_TESTING
 from ftw.builder import Builder
 from ftw.builder import create
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from Products.CMFCore.utils import getToolByName
@@ -110,6 +112,22 @@ class TestBrainSerializer(TestCase):
 
         self.assertEqual('Folder', folder.portal_type)
         self.assertEqual('Document', page.portal_type)
+
+    def test_converts_persistent_mutables_to_default_types(self):
+        # On the remote side the data is not stored, therfore we can
+        # convert persistent mutables to default types in order to be
+        # able to dump it to json.
+
+        serializer = BrainSerializer()
+        self.assertEquals(dict, type(serializer._encode(PersistentMapping())),
+                          'PersistentMapping should be converted to dict')
+        self.assertEquals(list, type(serializer._encode(PersistentList())),
+                          'PersistentList should be converted to list')
+
+        self.assertEquals(dict, type(serializer._encode({'dict': PersistentMapping()})['dict']),
+                          'Dicts should be encoded recursively')
+        self.assertEquals(list, type(serializer._encode([PersistentList()])[0]),
+                          'Lists should be encoded recursively')
 
 
 class TestBrainResultSet(TestCase):


### PR DESCRIPTION
PersistentMapping and PersistentList are not JSON serializable and must therefore be converted to built in types (dict and list).
Since the value is not expected to be stored on the remote site we can safely do this.