### PR TITLE
Watcher portlet feed: fix error when object was deleted.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Watcher portlet feed: fix error when object was deleted. [jone]
 
 
 1.0.13 (2016-01-20)

--- a/ftw/bridge/client/browser/watcher.py
+++ b/ftw/bridge/client/browser/watcher.py
@@ -126,7 +126,10 @@ class WatcherFeed(BrowserView):
         uid = self.request.get('uid')
         reference_catalog = getToolByName(self.context, 'reference_catalog')
         obj = reference_catalog.lookupObject(uid)
-        data = self.get_data(obj)
+        if obj is not None:
+            data = self.get_data(obj)
+        else:
+            data = None
         return json.dumps(data)
 
     def get_data(self, obj):


### PR DESCRIPTION
Fix an AttributeError when the watched object was deleted.